### PR TITLE
Prevent DataInspector from inspecting the map grid lines

### DIFF
--- a/src/geoaxis.jl
+++ b/src/geoaxis.jl
@@ -611,10 +611,10 @@ function Makie.initialize_block!(axis::GeoAxis)
     end
     # These are the grid plots from earlier.
     longridplot = lines!(scene, lonticks_line_obs; color=axis.xgridcolor, linewidth=axis.xgridwidth,
-        visible=axis.xgridvisible, linestyle=axis.xgridstyle, transparency=true)
+        visible=axis.xgridvisible, linestyle=axis.xgridstyle, transparency=true, inspectable=false)
     translate!(longridplot, 0, 0, 100)
     latgridplot = lines!(scene, latticks_line_obs; color=axis.ygridcolor, linewidth=axis.ygridwidth,
-        visible=axis.ygridvisible, linestyle=axis.ygridstyle, transparency=true)
+        visible=axis.ygridvisible, linestyle=axis.ygridstyle, transparency=true, inspectable=false)
     translate!(latgridplot, 0, 0, 100)
 
     # This creates the spines and ticklabels plots for the grid.


### PR DESCRIPTION
When I enabled the `DataInspector`, I saw that it popped up a tooltip whenever I was over a map grid line. It seems like that wouldn't be desirable (it certainly annoyed me). This PR disables inspectability of the map grid lines.