### PR TITLE
Example title fix: Regions of Italy

### DIFF
--- a/examples/italy.jl
+++ b/examples/italy.jl
@@ -1,5 +1,5 @@
 #=
-# States of Italy
+# Regions of Italy
 
 This example shows how to get data from a source and plot it using 
 GeoMakie.  It's more to show how to hybridize two data sources than 


### PR DESCRIPTION
Italy is split into 20 regions, not states.  Ref: https://en.wikipedia.org/wiki/Regions_of_Italy .