### PR TITLE
feat: Add `backgroundcolor` attribute to GeoAxis

### DIFF
--- a/src/geoaxis.jl
+++ b/src/geoaxis.jl
@@ -88,6 +88,8 @@ Makie.@Block GeoAxis <: Makie.AbstractAxis begin
         subtitlecolor::RGBAf = @inherit(:textcolor, :black)
         "The axis subtitle line height multiplier."
         subtitlelineheight::Float64 = 1
+        "The background color of the axis plot area. Defaults to `:white`. Set to `:transparent` or any `RGBAf` value to change the fill behind all map content."
+        backgroundcolor::RGBAf = :white
 
 
         "The xlabel string."
@@ -602,7 +604,7 @@ function Makie.initialize_block!(axis::GeoAxis)
         for lat in yticks
             range = LinRange(xticks[1], xticks[end], 100)
             project_tick_points!(lat_transformed, trans, trans_inverse, range, lat, 2, limit_rect,
-                                 spines.left, spines.right)
+                spines.left, spines.right)
         end
         lonticks_line_obs[] = lon_transformed
         latticks_line_obs[] = lat_transformed
@@ -685,32 +687,32 @@ function Makie.initialize_block!(axis::GeoAxis)
     # scatter!(axis.blockscene, latpoints, markersize=7, color=(:blue, 0.5))
 
     lattex = text!(axis.blockscene, lat_points_px;
-        text=lat_text, 
-        space=:pixel, 
+        text=lat_text,
+        space=:pixel,
         align=(:center, :center),
-        font=axis.xticklabelfont, 
+        font=axis.xticklabelfont,
         color=axis.xticklabelcolor,
-        fontsize=axis.xticklabelsize, 
+        fontsize=axis.xticklabelsize,
         visible=axis.xticklabelsvisible,
     )
 
     lontex = text!(axis.blockscene, lon_points_px;
-        text=lon_text, 
-        space=:pixel, 
+        text=lon_text,
+        space=:pixel,
         align=(:center, :center),
         font=axis.yticklabelfont,
         color=axis.yticklabelcolor,
-        fontsize=axis.yticklabelsize, 
+        fontsize=axis.yticklabelsize,
         visible=axis.yticklabelsvisible,
-        )
+    )
 
     fonts = theme(axis.blockscene, :fonts)
     # Finally calculate protrusions and report all bounding boxes
     # to the layout system.
     approx_x_protrusion = map(
-        axis.blockscene, 
+        axis.blockscene,
         axis.yticklabelfont, axis.yticklabelsize, axis.yticklabelpad, lat_text, axis.yticklabelsvisible
-        ) do ticklabel_font, ticklabel_size, ticklabel_pad, text, ticklabelsvisible
+    ) do ticklabel_font, ticklabel_size, ticklabel_pad, text, ticklabelsvisible
         ret = 0.0f0
 
         if ticklabelsvisible
@@ -726,9 +728,9 @@ function Makie.initialize_block!(axis::GeoAxis)
     end
 
     approx_y_protrusion = map(
-        axis.blockscene, 
+        axis.blockscene,
         axis.xticklabelfont, axis.xticklabelsize, axis.xticklabelpad, lon_text, axis.xticklabelsvisible,
-        ) do ticklabel_font, ticklabel_size, ticklabel_pad, text, ticklabelsvisible
+    ) do ticklabel_font, ticklabel_size, ticklabel_pad, text, ticklabelsvisible
 
         ret = 0.0f0
 
@@ -747,6 +749,15 @@ function Makie.initialize_block!(axis::GeoAxis)
 
     elements = Dict{Symbol,Any}()
     setfield!(axis, :elements, elements)
+    background = poly!(
+        axis.blockscene, scene.viewport;
+        color=axis.backgroundcolor,
+        inspectable=false,
+        shading=NoShading,
+        strokecolor=:transparent
+    )
+    translate!(background, 0, 0, -100)
+    elements[:background] = background
     elements[:xgrid] = longridplot
     elements[:ygrid] = latgridplot
     elements[:xticklabels] = lontex
@@ -799,7 +810,7 @@ function Makie.initialize_block!(axis::GeoAxis)
     xaxis = (; protrusion=approx_y_protrusion)
     map!(compute_protrusions, axis.blockscene, axis.layoutobservables.protrusions, axis.title, axis.titlesize,
         axis.titlegap, axis.titlevisible,
-        xaxis.protrusion, 
+        xaxis.protrusion,
         yaxis.protrusion,
         axis.subtitle, axis.subtitlevisible, axis.subtitlesize, axis.subtitlegap,
         axis.titlelineheight, axis.subtitlelineheight, subtitlet, titlet)
@@ -862,7 +873,7 @@ function Makie.plot!(axis::GeoAxis, plot::Makie.AbstractPlot)
     # remove the reset_limits kwarg if there is one, this determines whether to automatically reset limits
     # on plot insertion
     reset_limits = to_value(pop!(plot.kw, :reset_limits, true))
-    
+
     # actually plot
     Makie.plot!(axis.scene, plot)
 

--- a/test/geoaxis.jl
+++ b/test/geoaxis.jl
@@ -40,9 +40,9 @@ end
     @testset "GridBased" begin
         lons = -180:180
         lats = -90:90
-        
+
         field = [exp(cosd(l)) + 3(y/90) for l in lons, y in lats]
-        
+
         @test_nowarn heatmap!(ax, lons, lats, field)
         @test_nowarn surface!(ax, lons, lats, field)
         @test_nowarn contour!(ax, lons, lats, field)
@@ -70,6 +70,35 @@ end
     @test new_prots.top == 0
     @test new_prots.bottom == 0
 
+end
+
+@testset "backgroundcolor" begin
+    lons = -180:180
+    lats = -90:90
+    field = [exp(cosd(l)) + 3(y/90) for l in lons, y in lats]
+
+    @testset "default is white" begin
+        fig = Figure()
+        ax = GeoAxis(fig[1, 1])
+        surface!(ax, lons, lats, field; shading = NoShading)
+        @test ax.backgroundcolor[] == RGBAf(1, 1, 1, 1)
+        @test haskey(ax.elements, :background)
+    end
+
+    @testset "custom color at construction" begin
+        fig = Figure()
+        ax = GeoAxis(fig[1, 1]; backgroundcolor = :red)
+        surface!(ax, lons, lats, field; shading = NoShading)
+        @test ax.backgroundcolor[] == RGBAf(1, 0, 0, 1)
+    end
+
+    @testset "color update after construction" begin
+        fig = Figure()
+        ax = GeoAxis(fig[1, 1])
+        surface!(ax, lons, lats, field; shading = NoShading)
+        ax.backgroundcolor[] = RGBAf(0, 0, 0, 0)
+        @test ax.backgroundcolor[] == RGBAf(0, 0, 0, 0)
+    end
 end
 
 @testset "Aspect ratio is equal to Axis with DataAspect" begin


### PR DESCRIPTION
### Summary

- GeoAxis already declared a `backgroundcolor::RGBAf` attribute (defaulting to `:white`).
- This PR wires the attribute to an actual poly! drawn on blockscene, matching the behavior of Makie's own Axis.
- Tests are added to verify the default value, construction-time override, and post-construction update.

### Changes
`src/geoaxis.jl`
Expanded the doc string on backgroundcolor to describe the default and accepted values.
In initialize_block!, added a poly!(axis.blockscene, scene.viewport; color = axis.backgroundcolor, ...) after the elements dict is created, translated to z = -100 so it stays behind all map content. The plot handle is stored in `elements[:background]`.


```julia
using GeoMakie, CairoMakie
import GeometryOps as GO

fig = Figure()

ax = GeoAxis(
    fig[1, 1];
    dest = "+proj=aea +lon_0=110 +lat_1=25 +lat_2=47 +lat_0=0 +datum=WGS84 +units=m +no_defs",
    backgroundcolor = :lightblue1,  
)

land = GeoMakie.land()
land_dense = GO.segmentize.(land; max_distance=0.5)
poly!(ax, land_dense; color=:floralwhite)

## Add border

fig
```

<img width="1200" height="900" alt="display" src="https://github.com/user-attachments/assets/6263fb62-b1e1-48c8-9df5-cb4d5b1fa816" />

and another basic example:

<img width="1200" height="900" alt="display2" src="https://github.com/user-attachments/assets/dbf8db29-9d96-4046-8698-41227279dcfb" />
