### PR TITLE
Improve lighting in GlobeAxis

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -90,7 +90,7 @@ doc = Documenter.makedocs(;
     sitename="GeoMakie.jl",
     authors="Anshul Singhvi and the Makie.jl contributors",
     doctest=false,
-    warnonly = true,
+    warnonly = [:docs_block, :missing_docs],
     draft = false,
     plugins = [OhMyCards.ExampleConfig(; dot_slash = true),],
     pagesonly = !(get(ENV, "CI", "false") == "true"),

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ examples = String[
     "rotating_earth.jl",
     "sticker.jl",
     "piracy_at_sea.jl",
+    "geoid.jl",
     joinpath("specialized", "satellite", "dashboard.jl"),
     joinpath("specialized", "satellite", "sweep_points.jl"),
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -103,3 +103,8 @@ DocumenterVitepress.deploydocs(;
     push_preview = true,
     forcepush = true
 )
+
+fatal_errors = filter(Documenter.is_strict(doc), doc.internal.errors)
+if !isempty(fatal_errors)
+    error("Errors found in documentation build: $(join(fatal_errors, "\n"))")
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,13 +97,9 @@ doc = Documenter.makedocs(;
     debug = true,
 );
 
-DocumenterVitepress.deploydocs(; 
-    repo="github.com/MakieOrg/GeoMakie.jl", 
-    target="build", 
-    push_preview = true, 
+DocumenterVitepress.deploydocs(;
+    repo="github.com/MakieOrg/GeoMakie.jl",
+    target="build",
+    push_preview = true,
     forcepush = true
 )
-
-if length(doc.internal.errors) > 0
-    error("Errors found in documentation build: $(join(doc.internal.errors, "\n"))")
-end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -90,21 +90,20 @@ doc = Documenter.makedocs(;
     sitename="GeoMakie.jl",
     authors="Anshul Singhvi and the Makie.jl contributors",
     doctest=false,
-    warnonly = [:docs_block, :missing_docs],
+    warnonly = true,
     draft = false,
     plugins = [OhMyCards.ExampleConfig(; dot_slash = true),],
     pagesonly = !(get(ENV, "CI", "false") == "true"),
     debug = true,
 );
 
-DocumenterVitepress.deploydocs(;
-    repo="github.com/MakieOrg/GeoMakie.jl",
-    target="build",
-    push_preview = true,
+DocumenterVitepress.deploydocs(; 
+    repo="github.com/MakieOrg/GeoMakie.jl", 
+    target="build", 
+    push_preview = true, 
     forcepush = true
 )
 
-fatal_errors = filter(Documenter.is_strict(doc), doc.internal.errors)
-if !isempty(fatal_errors)
-    error("Errors found in documentation build: $(join(fatal_errors, "\n"))")
+if length(doc.internal.errors) > 0
+    error("Errors found in documentation build: $(join(doc.internal.errors, "\n"))")
 end

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -27,6 +27,7 @@ multiple_crs
 dashboard
 sweep_points
 vesta3d
+geoid
 ```
 
 ### GeoAxis examples

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -1,0 +1,61 @@
+using Rasters, ArchGDAL, Downloads
+using GeoMakie, GLMakie 
+
+path = Downloads.download("https://cdn.proj.org/us_nga_egm96_15.tif")
+gravitational_potential_ras = Raster(path) # geoid undulation, metres
+# The Proj provided EGM files are slightly weird in format, and thus off by 
+# half a pixel from where they should be due to point/area misunderstandings.
+# To fix this, we need to shift the raster by half a pixel.
+xdim, ydim = dims(gravitational_potential_ras, (X, Y))
+dx, dy = step(xdim), step(ydim)
+gravitational_potential_ras = set(gravitational_potential_ras, X => xdim .+ dx/2, Y => ydim .+ dy/2)  
+
+fig = Figure(size = (700, 700))
+ax  = GlobeAxis(fig[1,1])
+sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
+cl = lines!(ax, GeoMakie.coastlines(); color = :black, linewidth = 0.5, depth_shift = -.01)
+display(fig)   # let the camera/limits settle before reading them
+
+# --- Geocentric datum line + reference ellipsoid silhouette ----------------
+# Pick a (lon, lat) — here we just snapshot the current camera longitude/latitude —
+# and draw the geocentric vertical at that point: a dashed line from the Earth's
+# centre out through the surface tangent point. Then overlay a smooth red circle
+# at the un-exaggerated WGS84 semi-major axis, perpendicular to the (post-orbit)
+# view direction. Compared with the bumpy geoid surface (whose N is exaggerated
+# 10000×) this shows the ideal vs. real shape, the contrast in the reference figure.
+using LinearAlgebra: norm, cross, normalize
+
+cc = cameracontrols(ax.scene)
+lon, lat, _ = Makie.apply_transform(ax.inv_transform_func[], cc.eyeposition[])
+
+centre     = Point3f(0, 0, 0)
+surface_pt = Point3f(Makie.apply_transform(ax.transform_func[], Point3d(lon, lat, 0.0)))
+
+# Reference-ellipsoid silhouette in the plane perpendicular to the final view
+final_eye = Makie.apply_transform(ax.transform_func[], Point3d(lon - 90, 0.0, 0.0))
+d̂  = normalize(Vec3f(final_eye))
+u1 = normalize(cross(d̂, Vec3f(0, 0, 1)))
+u2 = normalize(cross(d̂, u1))
+a_wgs84 = 6_378_137.0
+ellipsoid_silhouette = [Point3f(a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in range(0, 2π; length = 361)]
+lines!(ax.scene, ellipsoid_silhouette;
+       color = :red, linewidth = 2.5, overdraw = true)
+
+# Plot into ax.scene (not ax) so the (lon,lat,alt)→ECEF transform isn't applied;
+# overdraw lets the segment buried inside the globe show through.
+lines!(ax.scene, [centre, surface_pt];
+       color = :red, linestyle = :dash, linewidth = 3, overdraw = true)
+scatter!(ax.scene, [centre, surface_pt];
+         color = [:black, :white], strokecolor = :black, strokewidth = 2,
+         markersize = 28, overdraw = true)
+text!(ax.scene, [centre, surface_pt];
+      text  = ["geocentre",
+               "$(round(lon;digits=1))°E, $(round(lat;digits=1))°N"],
+      align = [(:left, :bottom), (:right, :bottom)],
+      offset = [(12, 12), (-12, 12)],
+      fontsize = 16, overdraw = true)
+
+# Move the camera 90° around in longitude so the line is seen edge-on,
+# and tighten the FOV so the globe fills the square frame.
+update_cam!(ax; longlat = (lon - 90, 0.0), fov = 28)
+fig

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -31,7 +31,7 @@ sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
 # at each (lon, lat). This puts them at the same radial distance as the surface so
 # depth testing hides back-of-globe coastlines naturally — no depth_shift hack needed.
 draped = GO.transform(GeoMakie.coastlines()) do p
-    (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))])
+    (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))] + 1_000)
 end
 cl = lines!(ax, draped; color = :black, linewidth = 0.5)
 fig # hide

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -1,5 +1,16 @@
+#=
+# Geoid + datum reference
+
+A globe with an exaggerated EGM96 geoid surface, overlaid with the WGS84 geocentric datum and a translated "local" datum to illustrate how regionally-fit ellipsoids deviate from the geocentric reference.
+
+```@cardmeta
+Description = "Geoid surface with geocentric and local datum silhouettes"
+Cover = fig
+```
+=#
+
 using Rasters, ArchGDAL, Downloads
-using GeoMakie, GLMakie 
+using GeoMakie
 
 path = Downloads.download("https://cdn.proj.org/us_nga_egm96_15.tif")
 gravitational_potential_ras = Raster(path) # geoid undulation, metres
@@ -14,48 +25,62 @@ fig = Figure(size = (700, 700))
 ax  = GlobeAxis(fig[1,1])
 sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
 cl = lines!(ax, GeoMakie.coastlines(); color = :black, linewidth = 0.5, depth_shift = -.01)
-display(fig)   # let the camera/limits settle before reading them
 
-# --- Geocentric datum line + reference ellipsoid silhouette ----------------
-# Pick a (lon, lat) — here we just snapshot the current camera longitude/latitude —
-# and draw the geocentric vertical at that point: a dashed line from the Earth's
-# centre out through the surface tangent point. Then overlay a smooth red circle
-# at the un-exaggerated WGS84 semi-major axis, perpendicular to the (post-orbit)
-# view direction. Compared with the bumpy geoid surface (whose N is exaggerated
-# 10000×) this shows the ideal vs. real shape, the contrast in the reference figure.
+# --- Geocentric datum + local datum silhouettes ----------------------------
+# Plot two reference ellipsoid silhouettes against the bumpy geoid surface
+# (whose undulation N is exaggerated 10000×): the global geocentric datum
+# (WGS84, centred at Earth's mass centre) as a solid black circle, and a
+# local datum — a regional ellipsoid translated to better fit the geoid in
+# the visible area — as a dashed pink circle. Mirrors r.geocompx.org's
+# 02_datum_fig.png.
 using LinearAlgebra: norm, cross, normalize
 
 cc = cameracontrols(ax.scene)
 lon, lat, _ = Makie.apply_transform(ax.inv_transform_func[], cc.eyeposition[])
 
-centre     = Point3f(0, 0, 0)
 surface_pt = Point3f(Makie.apply_transform(ax.transform_func[], Point3d(lon, lat, 0.0)))
 
-# Reference-ellipsoid silhouette in the plane perpendicular to the final view
+# Build screen-aligned orthonormal frame in the plane perpendicular to the
+# (post-orbit) view direction. Flipped so +u1 = screen-right, +u2 = screen-up.
 final_eye = Makie.apply_transform(ax.transform_func[], Point3d(lon - 90, 0.0, 0.0))
 d̂  = normalize(Vec3f(final_eye))
-u1 = normalize(cross(d̂, Vec3f(0, 0, 1)))
-u2 = normalize(cross(d̂, u1))
+u1 = -normalize(cross(d̂, Vec3f(0, 0, 1)))   # screen-right
+u2 =  normalize(cross(d̂, u1))                # screen-up
 a_wgs84 = 6_378_137.0
-ellipsoid_silhouette = [Point3f(a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in range(0, 2π; length = 361)]
-lines!(ax.scene, ellipsoid_silhouette;
-       color = :red, linewidth = 2.5, overdraw = true)
+ts = range(0, 2π; length = 361)
+pink = RGBf(0.93, 0.27, 0.6)
 
-# Plot into ax.scene (not ax) so the (lon,lat,alt)→ECEF transform isn't applied;
-# overdraw lets the segment buried inside the globe show through.
-lines!(ax.scene, [centre, surface_pt];
-       color = :red, linestyle = :dash, linewidth = 3, overdraw = true)
-scatter!(ax.scene, [centre, surface_pt];
-         color = [:black, :white], strokecolor = :black, strokewidth = 2,
-         markersize = 28, overdraw = true)
-text!(ax.scene, [centre, surface_pt];
-      text  = ["geocentre",
-               "$(round(lon;digits=1))°E, $(round(lat;digits=1))°N"],
-      align = [(:left, :bottom), (:right, :bottom)],
-      offset = [(12, 12), (-12, 12)],
-      fontsize = 16, overdraw = true)
+# Geocentric datum: solid black circle at WGS84 semi-major axis, centred at origin.
+geocentric = [Point3f(a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in ts]
+lines!(ax.scene, geocentric;
+       color = :black, linewidth = 2.5, overdraw = true)
 
-# Move the camera 90° around in longitude so the line is seen edge-on,
+# Local datum: pink dashed circle, translated toward the surface region of
+# interest so it bulges out on that side and tucks inside on the opposite —
+# the visual signature of a regionally-fit ellipsoid.
+offset = 0.04 * a_wgs84 * normalize(surface_pt)
+local_datum = [Point3f(offset + a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in ts]
+lines!(ax.scene, local_datum;
+       color = pink, linestyle = :dash, linewidth = 2.5, overdraw = true)
+
+# Thin crosshairs through the geocentre, in the view plane.
+hl = 1.04 * a_wgs84
+lines!(ax.scene, [Point3f(-hl * u1), Point3f(hl * u1)];
+       color = :black, linewidth = 0.6, overdraw = true)
+lines!(ax.scene, [Point3f(-hl * u2), Point3f(hl * u2)];
+       color = :black, linewidth = 0.6, overdraw = true)
+
+# Annotation labels: top-left for Geocentric (index ≈ 135°), right for Local (index ≈ 0°).
+text!(ax.scene, geocentric[136];
+      text = "Geocentric\ndatum",
+      align = (:right, :bottom), offset = (-8, 4),
+      fontsize = 16, color = :black, overdraw = true)
+text!(ax.scene, local_datum[1];
+      text = "Local\ndatum",
+      align = (:left, :center), offset = (10, 0),
+      fontsize = 16, color = pink, overdraw = true)
+
+# Move the camera 90° around in longitude so the datum line is seen edge-on,
 # and tighten the FOV so the globe fills the square frame.
-update_cam!(ax; longlat = (lon - 90, 0.0), fov = 28)
+update_cam!(ax; longlat = (lon - 90, 0.0), fov = 22)
 fig

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -24,7 +24,19 @@ gravitational_potential_ras = set(gravitational_potential_ras, X => xdim .+ dx/2
 fig = Figure(size = (700, 700))
 ax  = GlobeAxis(fig[1,1])
 sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
-cl = lines!(ax, GeoMakie.coastlines(); color = :black, linewidth = 0.5, depth_shift = -.01)
+
+# Drape coastlines onto the (exaggerated) geoid surface itself by sampling the raster
+# at each (lon, lat). This puts them at the same radial distance as the surface so
+# depth testing hides back-of-globe coastlines naturally — no depth_shift hack needed.
+draped = Point3f[]
+for ls in GeoMakie.coastlines()
+    for pt in ls.points
+        z = 10_000 * gravitational_potential_ras[X(Near(pt[1])), Y(Near(pt[2]))]
+        push!(draped, Point3f(pt[1], pt[2], z))
+    end
+    push!(draped, Point3f(NaN, NaN, NaN))
+end
+cl = lines!(ax, draped; color = :black, linewidth = 0.5)
 
 # --- Geocentric datum + local datum silhouettes ----------------------------
 # Plot two reference ellipsoid silhouettes against the bumpy geoid surface

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -10,7 +10,8 @@ Cover = fig
 =#
 
 using Rasters, ArchGDAL, Downloads
-using GeoMakie
+using GeoMakie, GLMakie
+GLMakie.activate!() # hide
 import GeometryOps as GO
 
 path = Downloads.download("https://cdn.proj.org/us_nga_egm96_15.tif")
@@ -33,8 +34,8 @@ draped = GO.transform(GeoMakie.coastlines()) do p
     (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))])
 end
 cl = lines!(ax, draped; color = :black, linewidth = 0.5)
-
-# --- Geocentric datum + local datum silhouettes ----------------------------
+fig # hide
+# ### Geocentric datum + local datum silhouettes
 # Plot two reference ellipsoid silhouettes against the bumpy geoid surface
 # (whose undulation N is exaggerated 10000×): the global geocentric datum
 # (WGS84, centred at Earth's mass centre) as a solid black circle, and a
@@ -62,6 +63,7 @@ pink = RGBf(0.93, 0.27, 0.6)
 geocentric = [Point3f(a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in ts]
 lines!(ax.scene, geocentric;
        color = :black, linewidth = 2.5, overdraw = true)
+fig # hide
 
 # Local datum: pink dashed circle, translated toward the surface region of
 # interest so it bulges out on that side and tucks inside on the opposite —
@@ -70,6 +72,7 @@ offset = 0.04 * a_wgs84 * normalize(surface_pt)
 local_datum = [Point3f(offset + a_wgs84 * (cos(t) * u1 + sin(t) * u2)) for t in ts]
 lines!(ax.scene, local_datum;
        color = pink, linestyle = :dash, linewidth = 2.5, overdraw = true)
+fig # hide
 
 # Thin crosshairs through the geocentre, in the view plane.
 hl = 1.04 * a_wgs84

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -31,7 +31,7 @@ sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
 # at each (lon, lat). This puts them at the same radial distance as the surface so
 # depth testing hides back-of-globe coastlines naturally — no depth_shift hack needed.
 draped = GO.transform(GeoMakie.coastlines()) do p
-    (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))] + 1_000)
+    (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))] + 10_000)
 end
 cl = lines!(ax, draped; color = :black, linewidth = 0.5)
 fig # hide

--- a/examples/geoid.jl
+++ b/examples/geoid.jl
@@ -11,6 +11,7 @@ Cover = fig
 
 using Rasters, ArchGDAL, Downloads
 using GeoMakie
+import GeometryOps as GO
 
 path = Downloads.download("https://cdn.proj.org/us_nga_egm96_15.tif")
 gravitational_potential_ras = Raster(path) # geoid undulation, metres
@@ -28,13 +29,8 @@ sp = surface!(ax, gravitational_potential_ras .* 10_000; colormap = :turbo)
 # Drape coastlines onto the (exaggerated) geoid surface itself by sampling the raster
 # at each (lon, lat). This puts them at the same radial distance as the surface so
 # depth testing hides back-of-globe coastlines naturally — no depth_shift hack needed.
-draped = Point3f[]
-for ls in GeoMakie.coastlines()
-    for pt in ls.points
-        z = 10_000 * gravitational_potential_ras[X(Near(pt[1])), Y(Near(pt[2]))]
-        push!(draped, Point3f(pt[1], pt[2], z))
-    end
-    push!(draped, Point3f(NaN, NaN, NaN))
+draped = GO.transform(GeoMakie.coastlines()) do p
+    (p[1], p[2], 10_000 * gravitational_potential_ras[X(Near(p[1])), Y(Near(p[2]))])
 end
 cl = lines!(ax, draped; color = :black, linewidth = 0.5)
 

--- a/examples/sticker.jl
+++ b/examples/sticker.jl
@@ -34,6 +34,7 @@ stop += n
 
 ## Top boundary
 for lon in top_interrupted_lons
+    global stop
     lons[stop:stop + n-1] .= lon - epsilon + central_longitude
     lats[stop:stop + n-1] .= LinRange(90, 0, n)
     stop += n
@@ -49,6 +50,7 @@ stop += n
 
 ## Bottom boundary
 for lon in bottom_interrupted_lons
+    global stop
     lons[stop:stop + n-1] .= lon + epsilon + central_longitude
     lats[stop:stop + n-1] .= LinRange(-90, 0, n)
     stop += n

--- a/src/geojson.jl
+++ b/src/geojson.jl
@@ -94,6 +94,13 @@ end
 
 
 
+"""
+    to_multipoly(geom)
+
+Convert a polygon, vector of polygons, multipolygon, or any GeoInterface-compatible
+geometry into a `GeometryBasics.MultiPolygon`. `GeometryCollection`s are handled by
+extracting their polygon and multipolygon members and unioning them.
+"""
 to_multipoly(poly::GeometryBasics.Polygon) = GeometryBasics.MultiPolygon([poly])
 to_multipoly(poly::Vector{GeometryBasics.Polygon}) = GeometryBasics.MultiPolygon(poly)
 to_multipoly(mp::GeometryBasics.MultiPolygon) = mp

--- a/src/sphere/globeaxis.jl
+++ b/src/sphere/globeaxis.jl
@@ -64,7 +64,7 @@ Currently, these attributes are:
 
 ## Important attributes
 - `source = "+proj=longlat +datum=wgs84 +type=crs"`: set the default source CRS of the projection.  This is always normalized to the XY axis order, no matter what you write here.  This can also be overridden at any point by the source attribute to a plot.
-- `scenekw = (;)`: keyword arguments passed directly to the underlying `LScene`; this can be used to set lights etc.
+- `lights = automatic`: lights to install on the underlying scene. `automatic` installs a camera-locked three-point rig (key/fill/back) plus a low ambient — chosen so plots with shading enabled stay visible whichever side of the globe you're looking at. Pass a `Vector{<:Makie.AbstractLight}` to override; include an `AmbientLight` in the vector if you want non-zero ambient. Pass `[]` for a fully dark scene. The attribute is observable, so you can mutate it after construction (e.g. `ga.lights[] = [...]` or `ga.lights[] = automatic` to restore the default).
 - `show_axis = true`: whether to show the LScene's axis, or not.
 """
 Makie.@Block GlobeAxis <: Makie.AbstractAxis begin
@@ -286,7 +286,30 @@ Makie.@Block GlobeAxis <: Makie.AbstractAxis begin
         # "The color of the axis spine."
         # spinecolor::RGBAf = :black
         # spinetype::Symbol = :geospine
+
+        # lights
+        "Lights to install on the underlying scene. `automatic` installs a camera-locked three-point rig with a low ambient. Pass a vector to override; include an `AmbientLight` in the vector if you want non-zero ambient. Pass `[]` for a fully dark scene."
+        lights::Union{Makie.Automatic, <:AbstractVector{<:Makie.AbstractLight}} = Makie.automatic
     end
+end
+
+function _default_globe_rig()
+    return Makie.AbstractLight[
+        Makie.AmbientLight(Makie.RGBf(0.15, 0.15, 0.15)),
+        Makie.DirectionalLight(Makie.RGBf(0.85, 0.85, 0.85), Makie.Vec3f(-0.4, -0.3,  1.0), true),
+        Makie.DirectionalLight(Makie.RGBf(0.30, 0.30, 0.35), Makie.Vec3f( 0.5, -0.2,  1.0), true),
+        Makie.DirectionalLight(Makie.RGBf(0.20, 0.20, 0.25), Makie.Vec3f( 0.0,  0.6, -1.0), true),
+    ]
+end
+
+function _apply_lights!(scene, v)
+    lights = v === Makie.automatic ? _default_globe_rig() : collect(v)
+    ambient_idx = findlast(l -> l isa Makie.AmbientLight, lights)
+    ambient_color = ambient_idx === nothing ? Makie.RGBf(0, 0, 0) : lights[ambient_idx].color[]
+    rest = filter(l -> !(l isa Makie.AmbientLight), lights)
+    Makie.set_ambient_light!(scene, ambient_color)
+    Makie.set_lights!(scene, rest)
+    return
 end
 
 _geodesy_ellipsoid_from(g::Geodesy.Ellipsoid) = g
@@ -333,6 +356,10 @@ function Makie.initialize_block!(axis::GlobeAxis; scenekw = NamedTuple())
 
     setfield!(axis, :globe_limits, Observable{Rect3d}(Makie.boundingbox(axis.scene)))
     setfield!(axis, :elements, Dict{Symbol, Any}())
+
+    on(axis.scene, axis.lights; update = true) do v
+        _apply_lights!(axis.scene, v)
+    end
 
     return
 

--- a/test/globeaxis.jl
+++ b/test/globeaxis.jl
@@ -2,6 +2,82 @@ using Test
 using GeoMakie
 using Makie
 using Geodesy
+using Colors
+
+@testset "Lights — default install" begin
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1])
+
+    lights = Makie.get_lights(ga.scene)
+    @test length(lights) == 3
+    @test all(l -> l isa DirectionalLight, lights)
+    @test all(l -> l.camera_relative, lights)
+end
+
+@testset "Lights — construction-time override" begin
+    fig = Figure()
+    custom = [DirectionalLight(RGBf(1, 0, 0), Vec3f(-1, 0, 0))]
+    ga = GlobeAxis(fig[1, 1]; lights = custom)
+
+    lights = Makie.get_lights(ga.scene)
+    @test length(lights) == 1
+    @test lights[1] isa DirectionalLight
+    @test lights[1].color == RGBf(1, 0, 0)
+end
+
+@testset "Lights — reactive replace" begin
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1])
+    @test length(Makie.get_lights(ga.scene)) == 3   # default rig
+
+    ga.lights[] = [DirectionalLight(RGBf(0, 1, 0), Vec3f(1, 0, 0))]
+    lights = Makie.get_lights(ga.scene)
+    @test length(lights) == 1
+    @test lights[1].color == RGBf(0, 1, 0)
+end
+
+@testset "Lights — restore default" begin
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1])
+    ga.lights[] = [DirectionalLight(RGBf(1, 0, 0), Vec3f(-1, 0, 0))]
+    @test length(Makie.get_lights(ga.scene)) == 1
+
+    ga.lights[] = automatic
+    lights = Makie.get_lights(ga.scene)
+    @test length(lights) == 3
+    @test all(l -> l isa DirectionalLight, lights)
+    @test all(l -> l.camera_relative, lights)
+end
+
+@testset "Lights — ambient extraction" begin
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1]; lights = [
+        AmbientLight(RGBf(0.4, 0.0, 0.0)),
+        DirectionalLight(RGBf(1, 1, 1), Vec3f(-1, 0, 0)),
+        DirectionalLight(RGBf(0, 0, 1), Vec3f( 1, 0, 0)),
+    ])
+
+    lights = Makie.get_lights(ga.scene)   # excludes ambient
+    @test length(lights) == 2
+    @test all(l -> l isa DirectionalLight, lights)
+    @test ga.scene.compute[:ambient_color][] == RGBf(0.4, 0.0, 0.0)
+end
+
+@testset "Lights — empty vector" begin
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1]; lights = Makie.AbstractLight[])
+    @test isempty(Makie.get_lights(ga.scene))
+    @test ga.scene.compute[:ambient_color][] == RGBf(0, 0, 0)
+end
+
+@testset "Lights — shaded surface plots" begin
+    # Shaded plot under the default rig should construct + display without warnings.
+    fig = Figure()
+    ga = GlobeAxis(fig[1, 1])
+    @test_nowarn surface!(ga, -180..180, -90..90, zeros(32, 32); color = rand(RGBf, 32, 32))
+    @test_nowarn Makie.update_state_before_display!(ga)
+end
+
 @testset "Basic instantiation" begin
     fig = Figure()
     ga = @test_nowarn GlobeAxis(fig[1,1])


### PR DESCRIPTION
- Add a `lights` kwarg to the globe axis that will allow user configurable lights
- Automatic lights should follow the camera and look better than regular lights - NoShading should never be necessary
- Add a geoid example like the one from https://github.com/geocompx/geocompr/blob/bfe6cf0deb95651e89656b4f049391f522c3d521/code/02-datum-fig.R