### PR TITLE
docs: add API reference page with @autodocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -85,6 +85,7 @@ doc = Documenter.makedocs(;
             "Architecture" => "architecture.md",
             "Adding demos" => "adding_demos.md",
         ],
+        "API reference" => "api.md",
         "Examples" => joinpath.(("examples",), replace.(examples, (".jl" => ".md",))),
     ],
     sitename="GeoMakie.jl",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,10 @@
+# API reference
+
+This page lists all documented functions, types, and macros in GeoMakie.
+
+```@index
+```
+
+```@autodocs
+Modules = [GeoMakie]
+```


### PR DESCRIPTION
Adds a new **API reference** page (`docs/src/api.md`) that uses `@autodocs` to render every docstring in GeoMakie. This should fix the docs build/deploy CI failure like https://github.com/MakieOrg/GeoMakie.jl/actions/runs/26414110892/job/77754732010.

Note this will include internal/unexported symbols too. If documenting only the public API is preferred, this can be switched to `Public = true` filtering (or split into exported/internal sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code). I (@briochemc) did not make any changes as this is such a minimal PR. But happy to adjust anything you want @asinghvi17! 🙂 