### PR TITLE
docs: document create_globe_transform and GeodesyGlobeTransform

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -138,8 +138,9 @@ To plot a scalar field, simply use `surface!(ga, lonmin..lonmax, latmin..latmax,
 ```@docs
 GeoMakie.to_multipoly
 GeoMakie.geo2basic
-GeoMakie.GeoAxis
 GeoMakie.geoformat_ticklabels
-GeoMakie.meshimage
 
 ```
+
+`GeoAxis`, `meshimage`, and the rest of the public API are documented on the
+[API reference](@ref) page.

--- a/src/sphere/globetransform.jl
+++ b/src/sphere/globetransform.jl
@@ -1,14 +1,25 @@
 """
-    abstract type GlobeTransform 
+    abstract type GlobeTransform
 
-The supertype for all globe transforms.  
-    
+The supertype for all globe transforms.
+
 All subtypes must be callable with a Point, and have a field `zlevel`.
 
 Construct via [`create_globe_transform`](@ref).  Used in [`GlobeAxis`](@ref).
 """
 abstract type GlobeTransform end
 
+"""
+    create_globe_transform(dest, src, zlevel)
+
+Create a [`GlobeTransform`](@ref) that converts coordinates from the `src` CRS
+into geocentric Cartesian (ECEF) coordinates on the ellipsoid `dest`, offsetting
+each point's altitude by `zlevel`.
+
+Returns a [`GeodesyGlobeTransform`](@ref) when `dest` is a `Geodesy.Ellipsoid`
+and `src` is a Geodesy coordinate type (e.g. `Geodesy.LLA`); otherwise returns a
+Proj.jl-based [`ProjGlobeTransform`](@ref).
+"""
 function create_globe_transform(dest::Geodesy.Ellipsoid, src::Type, zlevel)
     return GeodesyGlobeTransform(dest, src, zlevel)
 end
@@ -83,6 +94,12 @@ end
 Makie.inverse_transform(f::ProjGlobeTransform) = InverseProjGlobeTransform(f)
 Makie.inverse_transform(f::InverseProjGlobeTransform) = ProjGlobeTransform(Base.inv(f.inv_transf), f.zlevel)
 
+"""
+    struct GeodesyGlobeTransform{CoordType, T} <: GlobeTransform
+
+Geodesy.jl based transformation to the `dest` ellipsoid, for source coordinates
+of type `CoordType` (e.g. `Geodesy.LLA`, `Geodesy.UTM`, `Geodesy.UTMZ`).
+"""
 struct GeodesyGlobeTransform{CoordType, T} <: GlobeTransform
     transf::T
     zlevel::Float64

--- a/src/sphere/globetransform.jl
+++ b/src/sphere/globetransform.jl
@@ -17,8 +17,11 @@ into geocentric Cartesian (ECEF) coordinates on the ellipsoid `dest`, offsetting
 each point's altitude by `zlevel`.
 
 Returns a [`GeodesyGlobeTransform`](@ref) when `dest` is a `Geodesy.Ellipsoid`
-and `src` is a Geodesy coordinate type (e.g. `Geodesy.LLA`); otherwise returns a
-Proj.jl-based [`ProjGlobeTransform`](@ref).
+and `src` is passed as a *type* (dispatched on `src::Type`). In practice `src`
+must be one of the coordinate types for which a `GeodesyGlobeTransform`
+constructor exists (`Geodesy.LLA`, `Geodesy.UTM`, `Geodesy.UTMZ`); other types
+raise a `MethodError`. Otherwise returns a Proj.jl-based
+[`ProjGlobeTransform`](@ref).
 """
 function create_globe_transform(dest::Geodesy.Ellipsoid, src::Type, zlevel)
     return GeodesyGlobeTransform(dest, src, zlevel)


### PR DESCRIPTION
## What

Adds docstrings for `create_globe_transform` and `GeodesyGlobeTransform` in `src/sphere/globetransform.jl`.

## Why

After the `@autodocs` API page was added (#377), the docs build on `master` still fails because some bindings are documented-but-unrendered or referenced via `@ref` without an anchor. This documents the two remaining `globetransform.jl` symbols:

- `create_globe_transform` — describes the actual dispatch: returns a `GeodesyGlobeTransform` when `dest` is a `Geodesy.Ellipsoid` and `src` is a Geodesy coordinate type, otherwise a Proj.jl-based `ProjGlobeTransform`, producing geocentric ECEF coordinates offset by `zlevel`.
- `GeodesyGlobeTransform` — needed so the `[GeodesyGlobeTransform](@ref)` cross-reference in the `create_globe_transform` docstring resolves (an unresolved `@ref` is itself a build error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
