### PR TITLE
Fix version picker on geo.makie.org: load versions.js from site root

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -1,0 +1,112 @@
+import { defineConfig } from 'vitepress'
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
+import { mathjaxPlugin } from './mathjax-plugin'
+import { juliaReplTransformer } from './julia-repl-transformer'
+import footnote from "markdown-it-footnote";
+import path from 'path'
+
+const mathjax = mathjaxPlugin()
+
+function getBaseRepository(base: string): string {
+  if (!base || base === '/') return '/';
+  const parts = base.split('/').filter(Boolean);
+  return parts.length > 0 ? `/${parts[0]}/` : '/';
+}
+
+const baseTemp = {
+  base: 'REPLACE_ME_DOCUMENTER_VITEPRESS',// TODO: replace this in makedocs!
+}
+
+const navTemp = {
+  nav: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+}
+
+const nav = [
+  ...navTemp.nav,
+  {
+    component: 'VersionPicker'
+  }
+]
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  base: 'REPLACE_ME_DOCUMENTER_VITEPRESS',// TODO: replace this in makedocs!
+  title: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  description: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  lastUpdated: true,
+  cleanUrls: true,
+  outDir: 'REPLACE_ME_DOCUMENTER_VITEPRESS', // This is required for MarkdownVitepress to work correctly...
+  head: [
+    ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
+    // GeoMakie deploys to a custom domain (https://geo.makie.org) whose root
+    // holds the shared `versions.js`. The DocumenterVitepress default uses
+    // `${getBaseRepository(baseTemp.base)}versions.js`, which resolves to the
+    // per-version folder (e.g. `/stable/versions.js`) — a path that does not
+    // exist on a root-hosted custom domain. The VersionPicker then times out
+    // and falls back to a lone "dev" entry. Load it from the site root instead
+    // so the full version list populates. `siteinfo.js` stays per-version.
+    ['script', {src: '/versions.js'}],
+    ['script', {src: `${baseTemp.base}siteinfo.js`}]
+  ],
+
+  markdown: {
+    codeTransformers: [juliaReplTransformer()],
+    config(md) {
+      md.use(tabsMarkdownPlugin);
+      md.use(footnote);
+      mathjax.markdownConfig(md);
+    },
+    theme: {
+      light: "github-light",
+      dark: "github-dark"
+    },
+  },
+  vite: {
+    plugins: [
+      mathjax.vitePlugin,
+    ],
+    define: {
+      __DEPLOY_ABSPATH__: JSON.stringify('REPLACE_ME_DOCUMENTER_VITEPRESS_DEPLOY_ABSPATH'),
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '../components')
+      }
+    },
+    optimizeDeps: {
+      exclude: [
+        '@nolebase/vitepress-plugin-enhanced-readabilities/client',
+        'vitepress',
+        '@nolebase/ui',
+      ],
+    },
+    ssr: {
+      noExternal: [
+        // If there are other packages that need to be processed by Vite, you can add them here.
+        '@nolebase/vitepress-plugin-enhanced-readabilities',
+        '@nolebase/ui',
+      ],
+    },
+  },
+  themeConfig: {
+    outline: 'deep',
+    logo: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    search: {
+      provider: 'local',
+      options: {
+        detailedView: true
+      }
+    },
+    nav,
+    sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    sidebarDrawer: 'REPLACE_ME_DOCUMENTER_VITEPRESS_SIDEBAR_DRAWER',
+    editLink: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    socialLinks: [
+      { icon: 'github', link: 'REPLACE_ME_DOCUMENTER_VITEPRESS' }
+    ],
+    footer: {
+      message: 'Made with <a href="https://luxdl.github.io/DocumenterVitepress.jl/dev/" target="_blank"><strong>DocumenterVitepress.jl</strong></a><br>',
+      copyright: `© Copyright ${new Date().getUTCFullYear()}.`
+    }
+  }
+})


### PR DESCRIPTION
## Problem

On <https://geo.makie.org/stable/>, the version dropdown shows up a couple seconds late and lists **only `dev`** — none of the released versions (`stable`, `v0.7`, `v0.4`) appear, even though they exist.

## Root cause

GeoMakie is hosted at the **root of a custom domain** (`geo.makie.org`, via the `CNAME` on `gh-pages`), and the shared `versions.js` lives at the **site root** (`/versions.js`). It is correctly generated and fully populated:

```js
// gh-pages:/versions.js
var DOC_VERSIONS = ["dev", "stable", "v0.7", "v0.4"];
```

But the deployed pages load it from the wrong path. The DocumenterVitepress default `config.mts` injects:

```js
['script', {src: `${getBaseRepository(baseTemp.base)}versions.js`}],
```

For a root-hosted custom domain, `baseTemp.base` is the per-version path (`/stable/`, `/dev/`), so `getBaseRepository` returns `/stable/` and the page requests **`/stable/versions.js`** — which does not exist (only the root `/versions.js` does):

| page | injected `<script src>` | exists? |
|---|---|---|
| GeoMakie `stable`/`dev` | `/stable/versions.js`, `/dev/versions.js` | ❌ |
| Makie `stable`/`dev` | `/versions.js` | ✅ |

With the script 404-ing, `window.DOC_VERSIONS` is never set, so `VersionPicker.vue` waits 5s and then falls back to a single hard-coded `dev` entry — exactly the observed symptom.

The DVP default template even flags this case in a comment right below the line: `// for custom domains, I guess if deploy_url is available`.

## Fix

Check in `docs/src/.vitepress/config.mts` (DocumenterVitepress otherwise generates it) and load `versions.js` from the site root, matching what **Makie.jl already does** for `docs.makie.org`:

```js
['script', {src: '/versions.js'}],
['script', {src: `${baseTemp.base}siteinfo.js`}]   // siteinfo.js stays per-version
```

The file is otherwise identical to the DVP 0.3.x default template, so all `REPLACE_ME_DOCUMENTER_VITEPRESS` placeholders are still filled by `makedocs`, and DVP continues to substitute its default `mathjax-plugin.ts` / `julia-repl-transformer.ts` (those are not overridden).

## Notes / rollout

- `dev` picks this up on the **next master build**; `stable` only after the **next tagged release** rebuilds the `stable/` folder.
- Trade-off: GeoMakie now pins its own `config.mts`, so future DVP template changes won't auto-apply to it (same trade-off Makie.jl made).

🤖 Generated with [Claude Code](https://claude.com/claude-code)