### PR TITLE
TEST — DocumenterVitepress#359 deploy_url fix (do not merge)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -56,6 +56,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 [sources]
 GeoMakie = {path = ".."}
 OhMyCards = {rev = "as/relpath", url = "https://github.com/asinghvi17/OhMyCards.jl/"}
+DocumenterVitepress = {url = "https://github.com/LuxDL/DocumenterVitepress.jl", rev = "as/deploy-url-fixes"}
 
 [compat]
 Documenter = "1"


### PR DESCRIPTION
## Purpose

This is a **test build only** and **MUST NOT be merged**.

This PR points `docs/Project.toml` at the `as/deploy-url-fixes` branch of [LuxDL/DocumenterVitepress.jl](https://github.com/LuxDL/DocumenterVitepress.jl) (via a `[sources]` override) instead of the registered release, in order to verify [DocumenterVitepress.jl#359](https://github.com/LuxDL/DocumenterVitepress.jl/pull/359).

That PR fixes how `MarkdownVitepress` derives the VitePress `base` path from `repo`/`deploy_url`:
- it now matches `^https?://` (the old `r"http[s?]://"` regex never actually matched plain `http://`)
- it strips trailing slashes from `repo`/`deploy_url`
- it correctly handles custom-domain deploy URLs with subpaths

GeoMakie deploys its docs to a custom domain (`deploy_url = "https://geo.makie.org"`), so this PR's CI run is meant to confirm that the `as/deploy-url-fixes` branch builds GeoMakie's docs with a correct VitePress `base` path and that the PR-preview deployment works as expected.

## Changes

Only `docs/Project.toml` is touched:
- Added `DocumenterVitepress = {url = "https://github.com/LuxDL/DocumenterVitepress.jl", rev = "as/deploy-url-fixes"}` to the existing `[sources]` table.
- `[compat]` was left unchanged — the existing `DocumenterVitepress = ">=0.2.1"` entry is an unbounded lower bound and already permits the v0.3.4 version reported by that branch.

No source, docs content, or CI changes.

## Do not merge

This is purely to exercise CI against an upstream fix branch. Once verified, this PR should be closed without merging.